### PR TITLE
Added check last chars is not found

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,6 +43,11 @@ function tokenize(state, silent) {
 		}
 	}
 
+	// not found the end
+	if (end === -1) {
+		return false;
+	}
+
 	// start tag
 	state.push('kbd_open', TAG, 1);
 	// parse inner

--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ function tokenize(state, silent) {
 		}
 	}
 
-	// not found the end
+	// input ended before closing sequence
 	if (end === -1) {
 		return false;
 	}

--- a/testdata/expected/dangling.html
+++ b/testdata/expected/dangling.html
@@ -6,4 +6,7 @@
 	<kbd>bar</kbd> ]] hey
 	<kbd>this</kbd> [[ <kbd>and that</kbd>
 	<kbd>that</kbd> ]] <kbd>and this</kbd>
+	[[ <em>some markup</em> [[ <code>more markup</code> <kbd>valid</kbd> <strong>even more</strong>
+	[[
+	[[<em>test</em>
 </p>

--- a/testdata/input/dangling.md
+++ b/testdata/input/dangling.md
@@ -5,3 +5,6 @@ Here are some combinations to confuse the parser:
 [[bar]] ]] hey
 [[this]] [[ [[and that]]
 [[that]] ]] [[and this]]
+[[ *some markup* [[ `more markup` [[valid]] **even more**
+[[
+[[*test*


### PR DESCRIPTION
Hi. Thanks for create plugin. it's so nice.
I found & fix a bug today. 

In the case of the following pattern, return true always.

1. `[[F1]]`
2. `[[`
3. `[[F1`

I think it should return false at pattern of 2 and 3.
Furthermore, when rendering with `md.render`, an infinite loop occurs when the input is `is [[alt`

I fixed this bug. Can you have a look at my code, please?
